### PR TITLE
Add redirects for VANN terms summary

### DIFF
--- a/www/conf.caddy
+++ b/www/conf.caddy
@@ -14,3 +14,9 @@ rewrite /whisky/terms     /whisky/terms.html
 
 redir /changesets   /changeset/schema 301
 redir /changesets/* /changeset/schema 301
+redir /vann/changes /vann/#changes 303
+redir /vann/example /vann/#example 303
+redir /vann/preferredNamespacePrefix /vann/#preferredNamespacePrefix 303
+redir /vann/preferredNamespaceUri /vann/#preferredNamespaceUri 303
+redir /vann/termGroup /vann/#termGroup 303
+redir /vann/usageNote /vann/#usageNote 303


### PR DESCRIPTION
This commit adds caddy redirects for the Terms Summary URIs found at http://purl.org/vocab/vann/.

At http://purl.org/vocab/vann under the Terms Summary section there are some URIs for various terms. It looks as if at one point, for example, https://vocab.org/vann/changes would redirect to https://vocab.org/vann/#changes, but this no longer occurs.

This commit restores those redirects.

No idea whether this is helpful. I was just trying to figure out why http://purl.org/vocab/vann/usageNote didn't work. It may also be something is wrong with PURL, in which case I need to fix it. If the latter is the case, please let me know. :)

Edited to update URIs.